### PR TITLE
Add migration command to Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: gunicorn mysite.wsgi --log-file -
+release: python manage.py migrate


### PR DESCRIPTION
Adds command for db migration to Procfile to enable auto-deployment on Heroku, as described in the [meeting](https://github.com/ponder-lab/ponder-lab.github.io/wiki/Meeting-on-Dec-10,-2021#Zhongwei)