### PR TITLE
Make migration command the first line in procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn mysite.wsgi --log-file -
 release: python manage.py migrate
+web: gunicorn mysite.wsgi --log-file -


### PR DESCRIPTION
Moving the migration command to the first line because the original change didn't work, following up on #159 