### PR TITLE
changing migration command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: python manage.py migrate
+release: python manage.py migrate --fake ponder
 web: gunicorn mysite.wsgi --log-file -


### PR DESCRIPTION
changing migration command to `python manage.py migrate --fake ponder`, because the original command tried to recreate all the tables. Found this solution in https://stackoverflow.com/questions/25924858/django-1-7-migrate-gets-error-table-already-exists/25925368#25925368