### PR TITLE
Remove migration file dependency

### DIFF
--- a/ponder/migrations/0013_alter_categorizer_name_not_unique.py
+++ b/ponder/migrations/0013_alter_categorizer_name_not_unique.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('ponder', '0001_initial'),
     ]
 
     operations = [


### PR DESCRIPTION
Remove migration file dependency to fix the error of referencing non-existing dependency.