### PR TITLE
conditionally rendering categorization table for bug fix only if there are entries

### DIFF
--- a/ponder/templates/ponder/categorizations_by_BugFixID.html
+++ b/ponder/templates/ponder/categorizations_by_BugFixID.html
@@ -85,6 +85,7 @@
   </div>
   </br>
 
+  {% if table.rows|length %}
   <div class="container">
     <nav class="navbar navbar-expand-lg bg-light" style="background-color: #e3f2fd;">
       <h3 style="font-size: 30px; line-height: 43px; font-family: Helvetica; text-align: center; color: #337ab7;">
@@ -95,6 +96,7 @@
   <div class="container">
     {% render_table table %}
   </div>
+  {% endif %}
 </body>
 
 </html>


### PR DESCRIPTION
## PR Summary
<!-- Short summary of the PR -->
Conditionally render bug fix categorization table.

## Details
<!-- Bullet points/details of the PR. Technical changes, implementation decision, etc... -->

- Addresses issue: https://github.com/ponder-lab/Imperative-DL-Study-Web-App/issues/162
- Only render the categorization table on the bug fix page, if there are entries.
- Adding a `{% if table.rows|length %}` on the template.

## Testing/QA
<!-- Details on testing/QA done for this PR. Post screenshots/caps here. -->

- Tested locally. Screencap below:

https://github.com/user-attachments/assets/6e6be3f5-8f07-4e7c-91e4-0e00da4186b2

