### PR TITLE
adding filter by SHA for bug fixes table

### DIFF
--- a/ponder/templates/ponder/bugfixes_table.html
+++ b/ponder/templates/ponder/bugfixes_table.html
@@ -1,5 +1,6 @@
 {% extends "ponder/base.html" %}
 {% load render_table from django_tables2 %}
+{% load bootstrap3 %}
 <!doctype html>
 <html>
 {% block body_block %}
@@ -14,12 +15,26 @@
 			left: 0;
 			top: 0;
 			z-index: 10;
-		}
+        }
 	</style>
 </head>
 
 <body>
 	<div class="container">
+        <nav class="navbar navbar-expand-lg bg-light" style="background-color: #e3f2fd;">
+            <div class="container-fluid">
+                <div class="navbar-header">
+                    <a class="navbar-brand" href="{% url 'ponder:commits_table' %}"
+                        style="font-size: 25px; font-family: Helvetica; color: #337ab7; width: 1000px;">Bug Fixes</a>
+                </div>
+                {% if filter %}
+                    <form action="" method="get" class="form form-inline">
+                        {% bootstrap_form filter.form layout='inline' %}
+                        {% bootstrap_button 'filter' %}
+                    </form>
+                {% endif %}
+            </div>
+        </nav>
 		{% render_table table %}
 	</div>
 </body>


### PR DESCRIPTION
## PR Summary
<!-- Short summary of the PR -->
Adding filter by SHA input option on the `bug_fixes` table.

## Details
<!-- Bullet points/details of the PR. Technical changes, implementation decision, etc... -->

- Partially address https://github.com/ponder-lab/Imperative-DL-Study-Web-App/issues/161 by adding a filter for the `but_fixes` table.
- Adding django tables filtering as suggested by their docs: https://django-tables2.readthedocs.io/en/latest/pages/filtering.html
- Does an exact match on the SHA, search with empty input to list all the entries.
- Does NOT include filtering for commits table, will need to look into this a bit more.

## Testing/QA
<!-- Details on testing/QA done for this PR. Post screenshots/caps here. -->

- Tested locally, screencap below.

https://github.com/user-attachments/assets/5c790057-cb9f-4c38-bd52-e424502d98a0

